### PR TITLE
feat: add Dockerfile and docker-compose for API and serverless services

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20
+
+WORKDIR /usr/src/app
+
+# Copy only package files first for cache optimization
+COPY api/package*.json ./api/
+COPY shared/package*.json ./shared/
+RUN cd api && npm install && cd ../shared && npm install
+
+# Copy full source
+COPY api ./api
+COPY shared ./shared
+
+# Build shared module
+RUN cd shared && npm run build
+
+# Set working directory to API
+WORKDIR /usr/src/app/api
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: weather-db
+    ports:
+      - '5432:5432'
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_DB: ${DB_NAME}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    container_name: weather-api
+    ports:
+      - '3000:3000'
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+
+  serverless:
+    build:
+      context: .
+      dockerfile: serverless/Dockerfile
+    container_name: weather-serverless
+    ports:
+      - '3001:3001'
+    environment:
+      SERVERLESS_ACCESS_KEY: ${SERVERLESS_ACCESS_KEY}
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+
+volumes:
+  pgdata:

--- a/serverless/Dockerfile
+++ b/serverless/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20
+
+ARG SERVERLESS_ACCESS_KEY
+ENV SERVERLESS_ACCESS_KEY=$SERVERLESS_ACCESS_KEY
+
+WORKDIR /usr/src/app
+
+COPY serverless/package*.json ./serverless/
+COPY shared/package*.json ./shared/
+
+RUN cd serverless && npm install && cd ../shared && npm install
+
+COPY serverless ./serverless
+COPY shared ./shared
+
+RUN cd shared && npm run build
+
+WORKDIR /usr/src/app/serverless
+
+CMD ["npm", "run", "dev"]
+

--- a/serverless/package-lock.json
+++ b/serverless/package-lock.json
@@ -38,25 +38,6 @@
         "typescript": "^5.4.5"
       }
     },
-    "../shared": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "pg": "^8.16.0",
-        "reflect-metadata": "^0.2.2",
-        "typeorm": "^0.3.24"
-      },
-      "devDependencies": {
-        "@types/node": "^22.15.18",
-        "@typescript-eslint/eslint-plugin": "^8.32.1",
-        "@typescript-eslint/parser": "^8.32.1",
-        "eslint": "^9.27.0",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-prettier": "^5.4.0",
-        "prettier": "^3.5.3",
-        "typescript": "^5.8.3"
-      }
-    },
     "../shared/dist": {},
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -170,16 +151,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -4966,10 +4937,14 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -5376,6 +5351,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6068,9 +6049,9 @@
       }
     },
     "node_modules/serverless-dotenv-plugin": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-1.1.5.tgz",
-      "integrity": "sha512-IcCgsJgMb3NBofHUrK7f8ej+9CbaUJ5hNZekJCxdTRKacFXU6be/sLJqKDnb1m4gaCFenPItqZIVN8bq49iEew==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-1.2.1.tgz",
+      "integrity": "sha512-gDzF/B1Ro7oEdaZ0pQ5eSxIU6Qng+uyTc6KquegQMChYrUKBCl0iHIoS7HqIYweGQt5Bo6FJFDJ4xq1cTEZO9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7084,9 +7065,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.3.tgz",
+      "integrity": "sha512-adBYQLivcg1jbdKEJeqScJJFvgm4qY9+3tXw+jdG6lkVeqRJEtiQmSWjmth8GKmDZuX7sYM4YFxQsf0AzMfGGw==",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -1,5 +1,8 @@
 service: weather-file-processor
 
+org: ${env:SERVERLESS_ORG_NAME}
+app: weather-app
+
 plugins:
   - serverless-dotenv-plugin
 
@@ -8,6 +11,7 @@ provider:
   runtime: nodejs20.x
   region: eu-west-1
   memorySize: 2048
+  licenseKey: ${env:SERVERLESS_ACCESS_KEY}
   
 
   vpc:


### PR DESCRIPTION
# Summary

This pull request introduces Docker support for local development by adding:

- `Dockerfile` for the Express.js API service
- `Dockerfile` for the Serverless Lambda service
- `docker-compose.yml` to orchestrate the API, Serverless, and PostgreSQL services

## Details

- Configured `Dockerfile` in `api/` to install dependencies and run the Express API on port `3000`
- Configured `Dockerfile` in `serverless/` to support deployment and local processing of the Lambda handler
- `docker-compose.yml`:
  - Defines services for `weather-api`, `weather-serverless`, and `weather-db`
  - Uses environment variables from `.env`
  - Mounts local `pgdata` volume for persistent PostgreSQL storage
  - Exposes ports for API (3000), Serverless (3001), and DB (5432)

