### PR TITLE
Add sample environment configuration files for various components

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,25 @@
+# Environment
+NODE_ENV=
+LOG_LEVEL=
+LAMBDA_DEMO_MODE=
+
+# PostgreSQL (local)
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASS=
+
+# Bucket (for serverless-offline-s3)
+BUCKET_NAME=
+
+# Initial user
+INITIAL_USER_NAME=
+INITIAL_USER_EMAIL=
+INITIAL_USER_PASSWORD_HASHED=
+
+# VPC (empty for local)
+SUBNET_1=
+SUBNET_2=
+SUBNET_3=
+SG_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ docker-compose.override.yml
 # Environment
 # ────────────────
 .env
-.env.*
 
 # ────────────────
 # OS-Specific

--- a/serverless/.env.sample
+++ b/serverless/.env.sample
@@ -1,0 +1,29 @@
+# Environnt | local, production
+NODE_ENV=
+
+# Required by Lambda VPC access
+SUBNET_1=
+SUBNET_2=
+SUBNET_3=
+SG_ID=
+
+# Bucket name
+BUCKET_NAME=
+
+# PostgreSQL (RDS or local)
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASS=
+
+# Logger level | fatal, error, warn, info, debug, trace, silent
+LOG_LEVEL=
+
+# Lambda function Demo | true, false
+LAMBDA_DEMO_MODE=
+
+# Initial User
+INITIAL_USER_NAME=
+INITIAL_USER_EMAIL=
+INITIAL_USER_PASSWORD_HASHED=

--- a/shared/.env.sample
+++ b/shared/.env.sample
@@ -1,0 +1,6 @@
+# PostgreSQL (RDS or local)
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASS=


### PR DESCRIPTION
This pull request introduces `.env.sample` files in three locations (`.env.sample`, `serverless/.env.sample`, and `shared/.env.sample`) to standardize environment variable configuration across different parts of the project. These changes aim to improve clarity and consistency in managing environment variables.

### Addition of `.env.sample` files:

* [`.env.sample`](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cR1-R25): Added a comprehensive `.env.sample` file for the root directory, including placeholders for environment variables related to PostgreSQL, bucket configuration, Lambda settings, VPC settings, and initial user credentials.
* [`serverless/.env.sample`](diffhunk://#diff-02a1411346e4285404b2cfbe261edbf938c0aba8bc2928d6fbff35325035a1f0R1-R29): Added a `.env.sample` file specific to the `serverless` folder, covering similar variables as the root file but tailored for serverless deployments.
* [`shared/.env.sample`](diffhunk://#diff-ef674f2ba0e1fb2596a8344230bd0206a89f2b7633f5e39104a37944d3e9cdbdR1-R6): Added a minimal `.env.sample` file in the `shared` folder, focused solely on PostgreSQL configuration.